### PR TITLE
Simplify Bookinfo instructions

### DIFF
--- a/topics/docs/examples/bookinfo.adoc
+++ b/topics/docs/examples/bookinfo.adoc
@@ -13,44 +13,37 @@ The following steps describe the deployment of Bookinfo application on Maistra r
 Install Maistra by following the instructions link:/docs/getting_started/install[here].
 
 
+=== Create Bookinfo project
+```
+  $ oc new-project bookinfo
+```
+
 === Update Security Context Constraints
-To add the service account used by Bookinfo application to anyuid and privileged SCCs in "myproject" namespace:
+To add the service account used by Bookinfo application to anyuid and privileged SCCs in "bookinfo" namespace:
 
 ```
-  $ oc adm policy add-scc-to-user anyuid -z default -n myproject
-  $ oc adm policy add-scc-to-user privileged -z default -n myproject
+  $ oc adm policy add-scc-to-user anyuid -z default -n bookinfo
+  $ oc adm policy add-scc-to-user privileged -z default -n bookinfo
 ```
 
-=== Deploying Bookinfo Application
+=== Deploy Bookinfo Application
 
-. Download `bookinfo.yaml` into your local directory:
+. Deploy the Bookinfo application in the bookinfo project:
 +
 ```
-  $ curl -o bookinfo.yaml https://raw.githubusercontent.com/Maistra/bookinfo/master/bookinfo.yaml
-```
-
-. Deploy the Bookinfo application in the "myproject" namespace:
-+
-```
-  $ oc apply -n myproject -f bookinfo.yaml
-```
-
-. Download `bookinfo-gateway.yaml` into your local directory:
-+
-```
-  $ curl -o bookinfo-gateway.yaml https://raw.githubusercontent.com/Maistra/bookinfo/master/bookinfo-gateway.yaml
+  $ oc -n bookinfo apply -f https://raw.githubusercontent.com/Maistra/bookinfo/master/bookinfo.yaml
 ```
 
 . Create the ingress gateway for Bookinfo:
 +
 ```
-  $ oc apply -f bookinfo-gateway.yaml
+  $ oc -n bookinfo apply -f https://raw.githubusercontent.com/Maistra/bookinfo/master/bookinfo-gateway.yaml
 ```
 
 . Set `GATEWAY_URL`:
 +
 ```
-  $ export GATEWAY_URL=$(oc get route -n istio-system istio-ingressgateway -o jsonpath='{.spec.host}')
+  $ export GATEWAY_URL=$(oc -n istio-system get route istio-ingressgateway -o jsonpath='{.spec.host}')
 ```
 
 
@@ -59,51 +52,33 @@ To add the service account used by Bookinfo application to anyuid and privileged
 To confirm that Bookinfo has been successfully deployed:
 
 ```
-  $ curl -o /dev/null -s -w "%{http_code}\n" http://$GATEWAY_URL/productpage
+  $ curl -o /dev/null -s -w "%{http_code}\n" http://${GATEWAY_URL}/productpage
 ```
 
-Alternatively, you can open `http://$GATEWAY_URL/productpage` in your browser.
+You should get `200` as a response. Alternatively, you can open it in your browser:
+```
+xdg-open http://${GATEWAY_URL}/productpage
+```
 
 === Add default destination rules
- . If you did not enable mutual TLS:
+ . If you did *not* enable mutual TLS:
 +
 ```
-  $ curl -o destination-rule-all.yaml https://raw.githubusercontent.com/istio/istio/release-1.0/samples/bookinfo/networking/destination-rule-all.yaml
-  $ oc apply -f destination-rule-all.yaml
+  $ oc -n bookinfo apply -f https://raw.githubusercontent.com/istio/istio/release-1.1/samples/bookinfo/networking/destination-rule-all.yaml
 ```
- . If you enabled mutual TLS:
+ . If you *did* enable mutual TLS:
 +
 ```
-  $ curl -o destination-rule-all-mtls.yaml https://raw.githubusercontent.com/istio/istio/release-1.0/samples/bookinfo/networking/destination-rule-all-mtls.yaml
-  $ oc apply -f destination-rule-all-mtls.yaml
+  $ oc -n bookinfo apply -f https://raw.githubusercontent.com/istio/istio/release-1.1/samples/bookinfo/networking/destination-rule-all-mtls.yaml
 ```
  . To list all available destination rules:
 +
 ```
-  $ oc get destinationrules -o yaml
+  $ oc -n bookinfo get destinationrules -o yaml
 ```
 
 === Cleanup
-. Download cleanup script:
-+
+Delete the bookinfo project - this will wipe everything we created above:
 ```
-  $ curl -o cleanup.sh https://raw.githubusercontent.com/Maistra/bookinfo/master/cleanup.sh && chmod +x ./cleanup.sh
-```
-
-. Delete the bookinfo virtualservice, gateway, and terminate the pods:
-+
-```
-  $ ./cleanup.sh
-  namespace ? [default] myproject
-```
-
-. Confirm shutdown:
-+
-```
-  $ oc get virtualservices -n myproject
-  No resources found.
-  $ oc get gateway -n myproject
-  No resources found.
-  $ oc get pods -n myproject
-  No resources found.
+  $ oc delete project bookinfo
 ```


### PR DESCRIPTION
By using less commands and using bookinfo namespace, which simplifies
the cleanup. We no longer need the cleanup.sh script.