### PR TITLE
Remove $ signs

### DIFF
--- a/topics/docs/examples/bookinfo.adoc
+++ b/topics/docs/examples/bookinfo.adoc
@@ -15,7 +15,7 @@ Install Maistra by following the instructions link:/docs/getting_started/install
 
 === Create Bookinfo project
 ```
-  $ oc new-project bookinfo
+  oc new-project bookinfo
 ```
 === Update Security Context Constraints
 
@@ -26,8 +26,8 @@ These changes are not required if you are using CNI.
 To add the service account used by Bookinfo application to anyuid and privileged SCCs in "bookinfo" project:
 
 ```
-  $ oc adm policy add-scc-to-user anyuid -z default -n bookinfo
-  $ oc adm policy add-scc-to-user privileged -z default -n bookinfo
+  oc adm policy add-scc-to-user anyuid -z default -n bookinfo
+  oc adm policy add-scc-to-user privileged -z default -n bookinfo
 ```
 
 === Deploy Bookinfo Application
@@ -35,19 +35,19 @@ To add the service account used by Bookinfo application to anyuid and privileged
 . Deploy the Bookinfo application in the bookinfo project:
 +
 ```
-  $ oc -n bookinfo apply -f https://raw.githubusercontent.com/Maistra/bookinfo/maistra-1.0/bookinfo.yaml
+  oc -n bookinfo apply -f https://raw.githubusercontent.com/Maistra/bookinfo/maistra-1.0/bookinfo.yaml
 ```
 
 . Create the ingress gateway for Bookinfo:
 +
 ```
-  $ oc -n bookinfo apply -f https://raw.githubusercontent.com/Maistra/bookinfo/maistra-1.0/bookinfo-gateway.yaml
+  oc -n bookinfo apply -f https://raw.githubusercontent.com/Maistra/bookinfo/maistra-1.0/bookinfo-gateway.yaml
 ```
 
 . Set `GATEWAY_URL`:
 +
 ```
-  $ export GATEWAY_URL=$(oc -n istio-system get route istio-ingressgateway -o jsonpath='{.spec.host}')
+  export GATEWAY_URL=$(oc -n istio-system get route istio-ingressgateway -o jsonpath='{.spec.host}')
 ```
 
 
@@ -56,7 +56,7 @@ To add the service account used by Bookinfo application to anyuid and privileged
 To confirm that Bookinfo has been successfully deployed:
 
 ```
-  $ curl -o /dev/null -s -w "%{http_code}\n" http://${GATEWAY_URL}/productpage
+  curl -o /dev/null -s -w "%{http_code}\n" http://${GATEWAY_URL}/productpage
 ```
 
 You should get `200` as a response. Alternatively, you can open it in your browser:
@@ -68,21 +68,21 @@ xdg-open http://${GATEWAY_URL}/productpage
  . If you did *not* enable mutual TLS:
 +
 ```
-  $ oc -n bookinfo apply -f https://raw.githubusercontent.com/istio/istio/release-1.1/samples/bookinfo/networking/destination-rule-all.yaml
+  oc -n bookinfo apply -f https://raw.githubusercontent.com/istio/istio/release-1.1/samples/bookinfo/networking/destination-rule-all.yaml
 ```
  . If you *did* enable mutual TLS:
 +
 ```
-  $ oc -n bookinfo apply -f https://raw.githubusercontent.com/istio/istio/release-1.1/samples/bookinfo/networking/destination-rule-all-mtls.yaml
+  oc -n bookinfo apply -f https://raw.githubusercontent.com/istio/istio/release-1.1/samples/bookinfo/networking/destination-rule-all-mtls.yaml
 ```
  . To list all available destination rules:
 +
 ```
-  $ oc -n bookinfo get destinationrules -o yaml
+  oc -n bookinfo get destinationrules -o yaml
 ```
 
 === Cleanup
 Delete the bookinfo project - this will wipe everything we created above:
 ```
-  $ oc delete project bookinfo
+  oc delete project bookinfo
 ```


### PR DESCRIPTION
The $ signs are copied when c&p on the web site. 
The change is consistent with the getting started guide.