### PR TITLE
Correct api version of code sample

### DIFF
--- a/topics/docs/examples/mesh-wide_rbac.adoc
+++ b/topics/docs/examples/mesh-wide_rbac.adoc
@@ -21,7 +21,7 @@ Creating the following resource in your control plane's namespace will enable RB
 
 [source,yaml]
 ----
-apiVersion: "maistra/v1"
+apiVersion: "rbac.maistra.io/v1"
 kind: ServiceMeshRbacConfig
 metadata:
   name: default


### PR DESCRIPTION
In the docs, the api version for Maistra rbac object is incorrect:

```
$ oc api-versions | grep maistra
authentication.maistra.io/v1
maistra.io/v1
rbac.maistra.io/v1
```

With rbac.maistra.io/v1, the sample works.
