### PR TITLE
Automatically update Maistra Installation Options from SMCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 #ignores output from ./scripts/buildGuides.sh
 
-#manually ignoring build dirs, 
+#manually ignoring build dirs,
 #feel free to make this better with a regex
 
 *~
@@ -12,4 +12,4 @@ html/
 */.DS_Store
 *.zip
 emender/results/*
-
+out

--- a/config.toml
+++ b/config.toml
@@ -11,9 +11,6 @@ languageCOde = "en-US"
 # Disqus Username
 disqusShortname = "disqus_shortname"
 
-# Google Analytics UA number
-googleAnalytics = "UA-XXXXXXXX-X"
-
 # Copyright of your post
 copyright = "© This post is licensed under a Creative Commons Attribution-NonCommercial 4.0 International License，please give source if you wish to quote or reproduce."
 
@@ -52,13 +49,12 @@ copyright = "© This post is licensed under a Creative Commons Attribution-NonCo
 
 [params]
   themeVariant="blue"
-  editURL="https://github.com/Maistra/maistra.github.io/edit/maistra-1.1/topics/"
   ordersectionsby="weight"
   disableBreadcrumb = true
   disableNextPrev = true
   showVisitedLinks = false
   disableInlineCopyToClipBoard = true
-  
+
 
   accent = "#006264"
   backgroundColor = "#f5f5f5"

--- a/data/release.yaml
+++ b/data/release.yaml
@@ -1,0 +1,7 @@
+maistraVersion: '1.2'
+
+#this is the GitHub branch of Maistra associated with this documentation.
+maistraBranch: 'maistra-1.2'
+
+googleAnalytics: UA-163911219-1
+

--- a/themes/hugo-theme-learn-master/layouts/partials/custom-footer.html
+++ b/themes/hugo-theme-learn-master/layouts/partials/custom-footer.html
@@ -3,3 +3,12 @@
     console.log("running some javascript");
 </script>
 -->
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ .Site.Data.release.googleAnalytics }}"></script>
+<script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+
+    gtag('config', '{{ .Site.Data.release.googleAnalytics }}');
+</script>

--- a/themes/hugo-theme-learn-master/layouts/partials/header.html
+++ b/themes/hugo-theme-learn-master/layouts/partials/header.html
@@ -43,12 +43,12 @@
               {{if not .IsHome}}
               <div>
                 <div id="top-bar">
-                {{ if and (or .IsPage .IsSection) .Site.Params.editURL }}
+                {{ if and (or .IsPage .IsSection) .Site.Data.release.maistraBranch }}
                   {{ $File := .File }}
                   {{ $Site := .Site }}
                   {{with $File.Path }}
                   <div id="top-github-link">
-                    <a class="github-link" title='{{T "Edit-this-page"}}' href="{{ $Site.Params.editURL }}{{ replace $File.Dir "\\" "/" }}{{ $File.LogicalName }}" target="blank">
+                    <a class="github-link" title='{{T "Edit-this-page"}}' href="https://github.com/Maistra/maistra.github.io/edit/{{ $Site.Data.release.maistraBranch }}{{ replace $File.Dir "\\" "/" }}{{ $File.LogicalName }}" target="blank">
                       <i class="fas fa-code-branch"></i>
                       <span id="top-github-link-text">{{T "Edit-this-page"}}</span>
                     </a>
@@ -70,7 +70,7 @@
                  {{if $showBreadcrumb}}
                     {{ template "breadcrumb" dict "page" . "value" .Title }}
                  {{ else }}
-                   {{ .Title }} 
+                   {{ .Title }}
                  {{ end }}
                   </span>
                 </div>
@@ -93,7 +93,7 @@
           {{$parent := .page.Parent }}
           {{ if $parent }}
             {{ $value := (printf "<a href='%s'>%s</a> > %s" $parent.URL $parent.Title .value) }}
-            {{ template "breadcrumb" dict "page" $parent "value" $value }} 
+            {{ template "breadcrumb" dict "page" $parent "value" $value }}
           {{else}}
             {{.value|safeHTML}}
           {{end}}

--- a/themes/hugo-theme-learn-master/layouts/partials/header.html
+++ b/themes/hugo-theme-learn-master/layouts/partials/header.html
@@ -48,7 +48,7 @@
                   {{ $Site := .Site }}
                   {{with $File.Path }}
                   <div id="top-github-link">
-                    <a class="github-link" title='{{T "Edit-this-page"}}' href="https://github.com/Maistra/maistra.github.io/edit/{{ $Site.Data.release.maistraBranch }}{{ replace $File.Dir "\\" "/" }}{{ $File.LogicalName }}" target="blank">
+                    <a class="github-link" title='{{T "Edit-this-page"}}' href="https://github.com/Maistra/maistra.github.io/edit/{{ $Site.Data.release.maistraBranch }}/{{ replace $File.Dir "\\" "/" }}{{ $File.LogicalName }}" target="blank">
                       <i class="fas fa-code-branch"></i>
                       <span id="top-github-link-text">{{T "Edit-this-page"}}</span>
                     </a>

--- a/tools/updateFields.sh
+++ b/tools/updateFields.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -x
+
+mkdir -p out
+maistraBranch=$(yq read data/release.yaml maistraBranch)
+maistraVersion=$(yq read data/release.yaml maistraVersion)
+
+wget https://raw.githubusercontent.com/Maistra/istio-operator/${maistraBranch}/resources/smcp-templates/v${maistraVersion}/base -O out/base
+wget https://raw.githubusercontent.com/Maistra/istio-operator/${maistraBranch}/resources/smcp-templates/v${maistraVersion}/servicemesh -O out/servicemesh
+wget https://raw.githubusercontent.com/Maistra/istio-operator/${maistraBranch}/resources/smcp-templates/v${maistraVersion}/maistra -O out/maistra
+yq merge out/base out/maistra > out/maistra.rendered
+yq merge out/base out/servicemesh > out/servicemesh.rendered
+
+getValue() {
+	yq read out/$1.rendered $2
+}
+
+input=$1
+replace=""
+while IFS= read -r line
+do
+	if [[ $replace ]]; then
+		echo "replacing: ${line} with: ${replace}"
+		echo ""
+
+		lineValues=($line)
+		argName=${lineValues[0]}
+		sed -i "s#${argName}.*#${argName} ${replace}#" ${input}
+
+		replace=""
+	fi
+	if [[ $line == *"//Value"* ]]; then
+		match=$line
+		matchValues=($match)
+		specFile=${matchValues[1]}
+		specPath=${matchValues[2]}
+		replace=$(getValue ${specFile} ${specPath})
+		echo "GetValue ${specPath} from ${specFile}. Value: ${replace}"
+	fi
+done < "$input"
+

--- a/topics/docs/installation/installation-options.adoc
+++ b/topics/docs/installation/installation-options.adoc
@@ -6,6 +6,7 @@ description: "This is a full listing of additional options available for a Maist
 weight: 5
 ---
 
+include::vars.adoc[]
 
 :toc:
 
@@ -28,12 +29,13 @@ charts. Many of the parameters supported by the installer are shown below.
 [[istio_global_values]]
 == Istio Global Values
 
-[source,yaml]
+
+[source,yaml,subs="attributes"]
 ----
   istio:
     global:
-      hub: my-private-registry.com/custom-namespace
-      tag: 1.1.0
+      hub: {defaultMaistraHub}
+      tag: {defaultMaistraTag}
       mtls:
         enabled: true
       proxy:
@@ -62,10 +64,10 @@ charts. Many of the parameters supported by the installer are shown below.
 | false
 |`hub`
 |The hub to use to pull the Istio images.
-| `maistra/`
+| `{defaultMaistraHub}`
 |`tag`
 |The tag to use to pull the Istio images.
-| 1.1.0
+| {defaultMaistraTag}
 |`imagePullSecrets`
 |If access to the registry providing the Istio images is secure, then an link:https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod[`imagePullSecret`] can be listed here.
 |none
@@ -113,15 +115,15 @@ These are the resources requested and may vary depending on your environment. Th
 |`cpu`
 |This is the maximum number of CPUs that proxy is allowed to use.
 | 2000m
-|`memory` 
-|This is the amount of memory that is requested in the environment.  
+|`memory`
+|This is the amount of memory that is requested in the environment.
 |1024Mi
 |=======
 
 [[Gateways]]
 == istio->gateways
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
   gateways:
     istio-egressgateway:
@@ -132,7 +134,7 @@ These are the resources requested and may vary depending on your environment. Th
       autoscaleEnabled: false
       autoscaleMin: 1
       autoscaleMax: 5
-      ior_enabled: false
+      ior_enabled: {defaultMaistraIOREnabled}
 
 ----
 
@@ -168,13 +170,13 @@ These are the resources requested and may vary depending on your environment. Th
 | 5
 |`ior_enabled`
 |This parameter controls whether IOR is enabled. link:../../comparison-with-istio/ior/[Learn more about IOR].
-| false
+| {defaultMaistraIOREnabled}
 |=======
 
 [[Mixer]]
 == istio -> mixer
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
   mixer:
     enabled: true
@@ -185,8 +187,8 @@ These are the resources requested and may vary depending on your environment. Th
       autoscaleEnabled: false
       resources:
         requests:
-          cpu: 10m
-          memory: 128Mi
+          cpu: {defaultMaistraMixerRequestsCPU}
+          memory: {defaultMaistraMixerRequestsMemory}
         limits:
 ----
 
@@ -213,10 +215,10 @@ These are the resources requested and may vary depending on your environment. Th
 |Parameter |Description |Default
 |`cpu`
 |This is the number of CPUs that are requested in the environment.
-|10m
+|{defaultMaistraMixerRequestsCPU}
 |`memory`
 |This is the amount of memory that is requested in the environment.
-|128Mi
+|{defaultMaistraMixerRequestsMemory}
 |=======
 
 [[telemetry_resources_limits]]
@@ -341,13 +343,13 @@ If you intend to use a custom image, you must override all three values of `hub`
 |Parameter |Description |Default
 |`hub`
 |delegates to Jaeger operator
-|`jaegertracing/` or `registry.redhat.io/openshift-service-mesh/`
+|`jaegertracing/` or `{defaultServiceMeshHub}`
 |`tag`
 |The tag that the Operator uses to pull the Jaeger images
 |delegates to Jaeger operator
 |`template`
 |The deployment template to use for Jaeger
-|`all-in-one`/`production-elasticsearch`
+|`{defaultMaistraJaegerTemplate}`/`{defaultServiceMeshJaegerTemplate}`
 |`memory->max_traces`
 | 100000
 | This sets the maximum number of traces.
@@ -383,7 +385,7 @@ These parameters apply in the `production-elasticsearch` template only.
 disablePolicyChecks must be false for 3scale to work.
 {{% /notice %}}
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
   threeScale:
     enabled: false
@@ -413,13 +415,13 @@ disablePolicyChecks must be false for 3scale to work.
 | `false`
 |`hub`
 |The repository to use to pull 3Scale images.
-| `quay.io/3scale` or `registry.redhat.io/openshift-service-mesh`
+| `{defaultMaistraThreeScaleHub}` or `{defaultServiceMeshThreeScaleHub}`
 |`image`
 |The image to use for the 3Scale adapter.
-| `3scale-istio-adapter` or `3scale-istio-adapter-rhel8`
+| `{defaultMaistraThreeScaleImage}` or `{defaultServiceMeshThreeScaleHub}`
 |`tag`
 |The image tag to use.
-| `v1.0.0` (for community) or `1.0.0` (product)
+| `{defaultMaistraThreeScaleTag}` (for community) or `{defaultServiceMeshThreeScaleTag}` (product)
 |`PARAM_THREESCALE_LISTEN_ADDR`
 |This sets the listen address for the gRPC server.
 |3333

--- a/vars.adoc
+++ b/vars.adoc
@@ -1,0 +1,48 @@
+// SMCP defaults
+//Value maistra spec.istio.global.tag
+:defaultMaistraTag: 1.1.0
+
+//Value maistra spec.istio.global.hub
+:defaultMaistraHub: docker.io/maistra
+
+//Value servicemesh spec.istio.global.hub
+:defaultServiceMeshHub: registry.redhat.io/openshift-service-mesh
+
+//Value maistra spec.threeScale.hub
+:defaultMaistraThreeScaleHub: quay.io/3scale
+
+//Value servicemesh spec.threeScale.hub
+:defaultServiceMeshThreeScaleHub: registry.redhat.io/openshift-service-mesh
+
+//Value maistra spec.threeScale.image
+:defaultMaistraThreeScaleImage: 3scale-istio-adapter
+
+//Value servicemesh spec.threeScale.tag
+:defaultServiceMeshThreeScaleTag: 1.0.0
+
+//Value maistra spec.threeScale.tag
+:defaultMaistraThreeScaleTag: v1.0.0
+
+//Value maistra spec.istio.tracing.jaeger.template
+:defaultMaistraJaegerTemplate: all-in-one
+
+//Value servicemesh spec.istio.tracing.jaeger.template
+:defaultServiceMeshJaegerTemplate: all-in-one
+
+//Value maistra spec.istio.mixer.telemetry.resources.requests.cpu
+:defaultMaistraMixerRequestsCPU: 10m
+
+//Value servicemesh spec.istio.mixer.telemetry.resources.requests.cpu
+:defaultServiceMeshMixerRequestsCPU: 10m
+
+//Value maistra spec.istio.mixer.telemetry.resources.requests.memory
+:defaultMaistraMixerRequestsMemory: 128Mi
+
+//Value servicemesh spec.istio.mixer.telemetry.resources.requests.memory
+:defaultServiceMeshMixerRequestsMemory: 128Mi
+
+//Value maistra spec.istio.gateways.istio-ingressgateway.ior_enabled
+:defaultMaistraIOREnabled: false
+
+//Value servicemesh spec.istio.gateways.istio-ingressgateway.ior_enabled
+:defaultServiceMeshIOREnabled: false


### PR DESCRIPTION
This PR does a couple of things: 

**Data/release.yaml**
Hugo will pick up the contents of the Data directory and include those as variables accessible throughout the site. This adds a single file that we can update for each release to specify the latest Maistra tag/version as well as the branch to use. Both the documentation and `tools/updateFields.sh` reference this file in order to determine the active release. 

**Auto Update of Values from SMCP**
- This is made up of `tools/updateFields.sh` and `vars.adoc`.
- `tools/updateFields.sh` will fetch base, servicemesh, and maistra from the istio-operator repo. It will then merge base and servicemesh into servicemesh.rendered and base and maistra into maistra.rendered. It will then look in the file specified via an argument to tools/updateFields.sh, which can be executed as `./tools/updateFields.sh vars.adoc`. In vars.adoc it will look for: 

```
//Value maistra spec.istio.global.hub
:defaultMaistraHub: docker.io/maistra
```
Matching `//Value`, it will determine whether to use the rendered Maistra SMCP or the rendered ServiceMesh SMCP, and fetch the value at `spec.istio.global.hub`, substituting it in the next line. 

`
:defaultMaistraHub: docker.io/maistra
`
Defines a variable `defaultMaistraHub`, which can then be referenced in documentation after including the file. 

**Google Analytics**
Tracks the page visits and other statistics to let us know what functionality users care about. 