### PR TITLE
Updated documentation for snippted istio_installation_minimal and for pilot

### DIFF
--- a/topics/docs/installation/installation-options.adoc
+++ b/topics/docs/installation/installation-options.adoc
@@ -246,6 +246,19 @@ These are the resources requested and may vary depending on your environment. Th
     autoscaleEnabled: false
     traceSampling: 100.0
 ----
+[options="header"]
+|=======
+|Parameter |Description |Default
+|`autoscaleEnabled`
+|This parameter controls whether auto scaling is enabled. The example above disables it to allow running Maistra in a smaller environment.
+| `false`
+|`traceSampling`
+|This value controls how often random sampling should occur. Increase for development/testing.
+|1.0
+|`jwksResolverExtraRootCA`
+| Additional root certificates for JWKSResolver. To define additional certificates, add certificates as pem file format to this key. It is required for self signed jwksUri in Istio Policies.
+|none
+|=======
 
 [[pilot_resources_requests]]
 === resources->requests
@@ -260,9 +273,6 @@ These are the resources requested and may vary depending on your environment.
 |`memory`
 |This is the amount of memory that is requested in the environment.
 | 128Mi
-|`traceSampling`
-|This value controls how often random sampling should occur. Increase for development/testing.
-|1.0
 |=======
 
 [[Kiali]]

--- a/topics/snippets/istio_installation_minimal.adoc
+++ b/topics/snippets/istio_installation_minimal.adoc
@@ -24,7 +24,8 @@ spec:
       istio-ingressgateway:
         # disable autoscaling for use in smaller environments
         autoscaleEnabled: false
-
+        # set to true to enable IOR
+        ior_enabled: false
     mixer:
       policy:
         # disable autoscaling for use in smaller environments


### PR DESCRIPTION
Hello, 

I added the key ior to the snippet istio_installation_minimal.adoc, because the key is in the default ServiceMeshControlPlane template. Furthermore I moved the table for pilot->request to pilot and added a key jwksResolverExtraRootCA to this table.

Olaf