### PR TITLE
MAISTRA-2302: Add maistra.io/api endpoint

### DIFF
--- a/static/api
+++ b/static/api
@@ -1,0 +1,1 @@
+<meta name="go-import" content="maistra.io/api git https://github.com/maistra/api">


### PR DESCRIPTION
This is for go modules to work, e.g.:

```sh
$ go get maistra.io/api
```