### PR TITLE
OSSM-2258: introduces maistra.io/xns-informer redirect

### DIFF
--- a/static/xns-informer
+++ b/static/xns-informer
@@ -1,0 +1,1 @@
+<meta name="go-import" content="maistra.io/xns-informer git https://github.com/maistra/xns-informer">


### PR DESCRIPTION
This is for go modules to have consistent way of dealing with our dependencies (as we already do with `maistra/api`)

```
go get maistra.io/xns-informer
```