### PR TITLE
Update field name containing the inject annotation

### DIFF
--- a/modules/ossm-automatic-sidecar-injection.adoc
+++ b/modules/ossm-automatic-sidecar-injection.adoc
@@ -21,7 +21,7 @@ When deploying an application, you must opt-in to injection by setting the `side
 $ oc get deployment sleep -o yaml
 ----
 
-. Add `sidecar.istio.io/inject` to the configuration YAML with a value of `"true"` in the `spec.template.metadata.annotations.sidecar.istio/inject` field. See the following example for an app called `sleep`.
+. Add `sidecar.istio.io/inject` to the configuration YAML with a value of `"true"` in the `spec.template.metadata.annotations` field. See the following example for an app called `sleep`.
 +
 .Sleep test application example sleep.yaml
 [source,yaml]


### PR DESCRIPTION
The documentation mentions the `sidecar.istio.io/inject` annotation should be placed in the field named `spec.template.metadata.annotations.sidecar.istio/inject` when it should actually go in the `spec.template.metadata.annotations`  field.